### PR TITLE
Fix build version override

### DIFF
--- a/content/en_us/shared/conrefs.dita
+++ b/content/en_us/shared/conrefs.dita
@@ -118,7 +118,7 @@
 
    <p><ph id="fullversionnumber">Version 4.4.2</ph></p>
    <p><ph id="shortversionnumber">4.4</ph></p>
-   <p><ph id="buildversionstring">STAGING</ph></p>
+   <p><ph id="buildversionstring">@BUILD_VERSION_STRING@</ph></p>
 
   </conbody>
  </concept>


### PR DESCRIPTION
Restore @BUILD_VERSION_STRING@ in conrefs.dita so it is replaced when building.