### PR TITLE
Fix css/js links for copy-to docs

### DIFF
--- a/tools/DITA-OT/plugins/com.oxygenxml.webhelp/xsl/dita/desktop/dita2webhelp.xsl
+++ b/tools/DITA-OT/plugins/com.oxygenxml.webhelp/xsl/dita/desktop/dita2webhelp.xsl
@@ -16,6 +16,25 @@ available in the base directory of this Oxygen Webhelp plugin.
   
   <!-- Enable debugging from here. --> 
   <xsl:param name="WEBHELP_DEBUG" select="false()"/>
+  <xsl:param name="PATH2PROJ">
+  	<xsl:call-template name="fixed-path2project"/>
+  </xsl:param>
+
+  <!--
+    When copy-to is used the path2project is incorrect, leading to broken
+    references for css and js in some pages
+  -->
+  <xsl:template name="fixed-path2project">
+  	<xsl:variable name="original-path">
+  	  <xsl:apply-templates select="/processing-instruction('path2project')[1]" mode="get-path2project"/>
+  	</xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($original-path,'/en_us/')">../</xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$original-path"/>       
+      </xsl:otherwise>  	
+    </xsl:choose>
+  </xsl:template>
   
   <!-- Normal Webhelp transformation, filtered. -->
   <xsl:template match="/">


### PR DESCRIPTION
Docs that use "copy-to" have incorrect paths for css and js (etc) resources causing display issues for the html output. Example pages are (currently broken, will be fixed when this pull request is merged):

https://docs.eucalyptuscloud.org/eucalyptus/4.4.2/index.html#image-guide/ig_task_eustore.html
https://docs.eucalyptuscloud.org/eucalyptus/4.4.2/index.html#security-guide/security_firewalls.html

The source for these uses copy-to, e.g. from image-guide.ditamap:

```
        <topicref href="image-guide/img_task_eustore.dita"
            copy-to="image-guide/ig_task_eustore.dita" keys="eustore"/>
```

The fix is to initialize the PATH2PROJ parameter correctly by checking for '/en_us/' in the path as this should never be used.