### PR TITLE
Install guide edge network example remove comma

### DIFF
--- a/content/en_us/install-guide/nw_edge_shared.dita
+++ b/content/en_us/install-guide/nw_edge_shared.dita
@@ -190,7 +190,7 @@ VNET_DHCPDAEMON="/usr/sbin/dhcpd"</codeblock>
                 "10.111.101.94",
                 "10.111.101.95"
             ]
-        },
+        }
     ]
 }</codeblock>
 				<p>For a multi-cluster deployment, add an additional


### PR DESCRIPTION
Remove incorrect comma from install guide edge network example.

Fixes corymbia/eucalyptus#154